### PR TITLE
Hotfix for spider's OMG 2.001

### DIFF
--- a/res/const.js
+++ b/res/const.js
@@ -123,7 +123,8 @@ var oldAqlite = fs.existsSync( path.join(appCurrentDirectory,'aqlite_old.swf'));
 exports.aqlitePath = oldAqlite ? 
             _getFileUrl(path.join(appCurrentDirectory, 'aqlite_old.swf')) :
             //_getFileUrl(path.join(appRoot, 'aqlite.swf'))
-            'https://game.aq.com/game/gamefiles/Loader_Spider.swf';
+            //'https://game.aq.com/game/gamefiles/Loader_Spider.swf';           // not working since OMG 2.001
+            'https://game.aq.com/game/gamefiles/Loader_Spider.swf?ver=2001'    // gamefiles/Loader_Spider.swf?ver=2001
 exports.isOldAqlite = oldAqlite;
 
 /// -------------------------------


### PR DESCRIPTION
God dang it spider.... i was just saying nice things and this scared me -_-

its working now at least. but i am Sorry to say you need to reinstall it... : (

(WINDOWS ONLY) - but I dont want to reinstall
- Go to where Aquastar executable is installed
- Go to resources -> App -> res -> const.js (or just search for the file...)
- Change 'https://game.aq.com/game/gamefiles/Loader_Spider.swf', adding a '?ver=2001' at the end.
- Should be 'https://game.aq.com/game/gamefiles/Loader_Spider.swf?ver=2001'
- Save the file, try to run the game