### PR TITLE
Update const.js

### DIFF
--- a/res/const.js
+++ b/res/const.js
@@ -139,7 +139,7 @@ exports.listValidKeybindLocations = listValidKeybindLocations;
 var oldAqlite = fs.existsSync( path.join(appCurrentDirectory,'aqlite_old.swf'));
 exports.mainPath = oldAqlite ? 
             _getFileUrl(path.join(appCurrentDirectory, 'aqlite_old.swf')) :
-            "https://game.aq.com/game/gamefiles/Loader2.swf?ver=a"
+            "https://game.aq.com/game/gamefiles/Loader3.swf?ver=a"
 exports.isOldAqlite = oldAqlite;
 
 exports.changeMainUrl = function(newAqUrl){


### PR DESCRIPTION
Spider and his versioning..... siiiiigh....

Updated aqw launcher version to 3. just a URL change... (a SINGLE CHARACTER. all it took -_-)

Sorry guys. 1.5.1 release will come as soon as i figure out how to compile it on windows.... but if you cant wait, there is 2 alternatives.
Option 1 - Windows users only 
- Go to C:\Users(yourusername)\AppData\Local\Programs\AquaStar\resources\app\res\const.js
- Find the URL https://game.aq.com/game/gamefiles/Loader2.swf?ver=a and change it to https://game.aq.com/game/gamefiles/Loader3.swf?ver=a. Basically, change from 2 to 3.
- Thats it. Play the game.

Option 2 - Custom URL feature.
- Create a aquastar.json file in the places the F1 menu says (use the KEYBINDINGS.md on github to guide yourself) and add the secret feature of custom url:
- "customUrl" : "https://game.aq.com/game/gamefiles/Loader3.swf?ver=a"
- This option will load the url instead of the default url, and this was intended for old lost flash games someone wished to play again (childhood stuff yk). Its a bit harder to use but... sorry.
- If you cant figure out how to, drop the attached file (RENAME IT FROM .MD TO .JSON, BLAME GITHUB) in the place the F1 menu says it.
[aquastar.md](https://github.com/aquaspy/AquaStar/files/7613924/aquastar.md)